### PR TITLE
Fix bugs

### DIFF
--- a/src/aiida_atomistic/data/structure/utils.py
+++ b/src/aiida_atomistic/data/structure/utils.py
@@ -764,3 +764,23 @@ def create_automatic_kind_name(symbols, weights):
     if has_vacancies(weights):
         name_string += "X"
     return name_string
+
+
+def find_unique(prop_array, thr):
+    """Return a list that index the prop with same number if their value is under thr"""
+
+    num_sites = len(prop_array)
+    indexes = np.zeros(num_sites, int)
+    current_index=0
+    for i in range(1, num_sites):
+        current_index += 1
+        indexes[i] = current_index
+        # the first site is always marked as `0`
+        for j in range(i):
+            if np.linalg.norm(prop_array[j] - prop_array[i]) < thr:
+                indexes[i] = indexes[j]
+                current_index -= 1
+                break
+    return indexes
+
+


### PR DESCRIPTION
- Fix the criteria for determining whether two properties are the same in `_to_kinds`.
-- E.g. 0.199_Mn3Sn in examples, there are 3 kinds of magmoms.
-- Mn0: (1.5, 1.5*sqrt(3), 0); Mn1: (-3, 0, 0); Mn2: (1.5, -1.5*sqrt(3), 0)
-- it will give Mn1 and Mn2 the same label because norm(Mn2-Mn0) == norm(Mn1-Mn0) 
- Fix `to_dict(detect_kinds=True)` sometimes give wrong positions.
-- In step 2, `kind_numeration` may append same kinds repeatedly.
-- `kind_numeration` have different order with other properties.
-- In step 3, it will give a same position to same kinds (positions should be different).
- Remove unused variable.
-- In step 2 of `to_dict`, `kinds` and `check_array` have similar functionality and do not be used later.
- Match the `kinds` and `site.kind_name` in `to_dict`